### PR TITLE
Previous picks page

### DIFF
--- a/app/controllers/users/user_picks_controller.rb
+++ b/app/controllers/users/user_picks_controller.rb
@@ -1,7 +1,6 @@
 class Users::UserPicksController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    # require 'pry'; binding.pry
     @races = F1Facade.new.get_schedule(@user.seasons.last.season_year)
   end
 end

--- a/app/controllers/users/user_picks_controller.rb
+++ b/app/controllers/users/user_picks_controller.rb
@@ -1,6 +1,10 @@
-class Users::UserPicksController < ApplicationController
-  def index
-    @user = User.find(params[:user_id])
-    @races = F1Facade.new.get_schedule(@user.seasons.last.season_year)
+# frozen_string_literal: true
+
+module Users
+  class UserPicksController < ApplicationController
+    def index
+      @user = User.find(params[:user_id])
+      @races = F1Facade.new.get_schedule(@user.seasons.last.season_year)
+    end
   end
 end

--- a/app/controllers/users/user_picks_controller.rb
+++ b/app/controllers/users/user_picks_controller.rb
@@ -1,0 +1,7 @@
+class Users::UserPicksController < ApplicationController
+  def index
+    @user = User.find(params[:user_id])
+    # require 'pry'; binding.pry
+    @races = F1Facade.new.get_schedule(@user.seasons.last.season_year)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,6 @@ class User < ApplicationRecord
     user_picks.each do |user_pick|
       sum += user_pick.points_earned
     end
-    update(total_points: sum)
+    self.update(total_points: sum)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,6 @@ class User < ApplicationRecord
     user_picks.each do |user_pick|
       sum += user_pick.points_earned
     end
-    self.update(total_points: sum)
+    update(total_points: sum)
   end
 end

--- a/app/models/user_pick.rb
+++ b/app/models/user_pick.rb
@@ -48,4 +48,61 @@ class UserPick < ApplicationRecord
 
     update(points_earned: self.points_earned += 10)
   end
+
+  def self.purify_pick_names
+    driver_names = {
+      "albon" => "Alexander Albon",
+      "alonso" => "Fernando Alonso",
+      "bottas" => "Valtteri Bottas",
+      "de_vries" => "Nyck de Vries",
+      "gasly" => "Pierre Gasly",
+      "hamilton" => "Lewis Hamilton",
+      "hulkenberg" => "Nico Hülkenberg",
+      "leclerc" => "Charles Leclerc",
+      "kevin_magnussen" => "Kevin Magnussen",
+      "norris" => "Lando Norris",
+      "ocon" => "Esteban Ocon",
+      "perez" => "Sergio Pérez",
+      "piastri" => "Oscar Piastri",
+      "ricciardo" => "Daniel Ricciardo",
+      "russell" => "George Russell",
+      "sainz" => "Carlos Sainz",
+      "sargeant" => "Logan Sargeant",
+      "stroll" => "Lance Stroll",
+      "tsunoda" => "Yuki Tsunoda",
+      "max_verstappen" => "Max Verstappen",
+      "zhou" => "Guanyu Zhou"
+    }
+    
+    track_names = {
+      "bahrain" => "Bahrain Grand Prix",
+      "jeddah" => "Saudi Arabian Grand Prix",
+      "albert_park" => "Australian Grand Prix",
+      "baku" => "Azerbaijan Grand Prix",
+      "miami" => "Miami Grand Prix",
+      "monaco" => "Monaco Grand Prix",
+      "catalunya" => "Spanish Grand Prix",
+      "villeneuve" => "Canadian Grand Prix",
+      "red_bull_ring" => "Austrian Grand Prix",
+      "silverstone" => "British Grand Prix",
+      "hungaroring" => "Hungarian Grand Prix",
+      "spa" => "Belgian Grand Prix",
+      "zandvoort" => "Dutch Grand Prix",
+      "monza" => "Italian Grand Prix",
+      "marina_bay" => "Singapore Grand Prix",
+      "suzuka" => "Japanese Grand Prix",
+      "losail" => "Qatar Grand Prix",
+      "americas" => "United States Grand Prix",
+      "rodriguez" => "Mexico City Grand Prix",
+      "interlagos" => "São Paulo Grand Prix",
+      "vegas" => "Las Vegas Grand Prix",
+      "yas_marina" => "Abu Dhabi Grand Prix"
+    }
+
+    UserPick.all.each do |pick|
+      pick.update(driver_id: driver_names["#{pick.driver_id_tenth}"])
+      pick.update(race_name: track_names["#{pick.circuit_id}"])
+      pick.update(dnf_name: driver_names["#{pick.driver_id_dnf}"])
+    end
+  end
 end

--- a/app/models/user_pick.rb
+++ b/app/models/user_pick.rb
@@ -51,58 +51,58 @@ class UserPick < ApplicationRecord
 
   def self.purify_pick_names
     driver_names = {
-      "albon" => "Alexander Albon",
-      "alonso" => "Fernando Alonso",
-      "bottas" => "Valtteri Bottas",
-      "de_vries" => "Nyck de Vries",
-      "gasly" => "Pierre Gasly",
-      "hamilton" => "Lewis Hamilton",
-      "hulkenberg" => "Nico Hülkenberg",
-      "leclerc" => "Charles Leclerc",
-      "kevin_magnussen" => "Kevin Magnussen",
-      "norris" => "Lando Norris",
-      "ocon" => "Esteban Ocon",
-      "perez" => "Sergio Pérez",
-      "piastri" => "Oscar Piastri",
-      "ricciardo" => "Daniel Ricciardo",
-      "russell" => "George Russell",
-      "sainz" => "Carlos Sainz",
-      "sargeant" => "Logan Sargeant",
-      "stroll" => "Lance Stroll",
-      "tsunoda" => "Yuki Tsunoda",
-      "max_verstappen" => "Max Verstappen",
-      "zhou" => "Guanyu Zhou"
+      'albon' => 'Alexander Albon',
+      'alonso' => 'Fernando Alonso',
+      'bottas' => 'Valtteri Bottas',
+      'de_vries' => 'Nyck de Vries',
+      'gasly' => 'Pierre Gasly',
+      'hamilton' => 'Lewis Hamilton',
+      'hulkenberg' => 'Nico Hülkenberg',
+      'leclerc' => 'Charles Leclerc',
+      'kevin_magnussen' => 'Kevin Magnussen',
+      'norris' => 'Lando Norris',
+      'ocon' => 'Esteban Ocon',
+      'perez' => 'Sergio Pérez',
+      'piastri' => 'Oscar Piastri',
+      'ricciardo' => 'Daniel Ricciardo',
+      'russell' => 'George Russell',
+      'sainz' => 'Carlos Sainz',
+      'sargeant' => 'Logan Sargeant',
+      'stroll' => 'Lance Stroll',
+      'tsunoda' => 'Yuki Tsunoda',
+      'max_verstappen' => 'Max Verstappen',
+      'zhou' => 'Guanyu Zhou'
     }
-    
+
     track_names = {
-      "bahrain" => "Bahrain Grand Prix",
-      "jeddah" => "Saudi Arabian Grand Prix",
-      "albert_park" => "Australian Grand Prix",
-      "baku" => "Azerbaijan Grand Prix",
-      "miami" => "Miami Grand Prix",
-      "monaco" => "Monaco Grand Prix",
-      "catalunya" => "Spanish Grand Prix",
-      "villeneuve" => "Canadian Grand Prix",
-      "red_bull_ring" => "Austrian Grand Prix",
-      "silverstone" => "British Grand Prix",
-      "hungaroring" => "Hungarian Grand Prix",
-      "spa" => "Belgian Grand Prix",
-      "zandvoort" => "Dutch Grand Prix",
-      "monza" => "Italian Grand Prix",
-      "marina_bay" => "Singapore Grand Prix",
-      "suzuka" => "Japanese Grand Prix",
-      "losail" => "Qatar Grand Prix",
-      "americas" => "United States Grand Prix",
-      "rodriguez" => "Mexico City Grand Prix",
-      "interlagos" => "São Paulo Grand Prix",
-      "vegas" => "Las Vegas Grand Prix",
-      "yas_marina" => "Abu Dhabi Grand Prix"
+      'bahrain' => 'Bahrain Grand Prix',
+      'jeddah' => 'Saudi Arabian Grand Prix',
+      'albert_park' => 'Australian Grand Prix',
+      'baku' => 'Azerbaijan Grand Prix',
+      'miami' => 'Miami Grand Prix',
+      'monaco' => 'Monaco Grand Prix',
+      'catalunya' => 'Spanish Grand Prix',
+      'villeneuve' => 'Canadian Grand Prix',
+      'red_bull_ring' => 'Austrian Grand Prix',
+      'silverstone' => 'British Grand Prix',
+      'hungaroring' => 'Hungarian Grand Prix',
+      'spa' => 'Belgian Grand Prix',
+      'zandvoort' => 'Dutch Grand Prix',
+      'monza' => 'Italian Grand Prix',
+      'marina_bay' => 'Singapore Grand Prix',
+      'suzuka' => 'Japanese Grand Prix',
+      'losail' => 'Qatar Grand Prix',
+      'americas' => 'United States Grand Prix',
+      'rodriguez' => 'Mexico City Grand Prix',
+      'interlagos' => 'São Paulo Grand Prix',
+      'vegas' => 'Las Vegas Grand Prix',
+      'yas_marina' => 'Abu Dhabi Grand Prix'
     }
 
     UserPick.all.each do |pick|
-      pick.update(driver_id: driver_names["#{pick.driver_id_tenth}"])
-      pick.update(race_name: track_names["#{pick.circuit_id}"])
-      pick.update(dnf_name: driver_names["#{pick.driver_id_dnf}"])
+      pick.update(driver_id: driver_names[pick.driver_id_tenth.to_s])
+      pick.update(race_name: track_names[pick.circuit_id.to_s])
+      pick.update(dnf_name: driver_names[pick.driver_id_dnf.to_s])
     end
   end
 end

--- a/app/models/users/user_pick.rb
+++ b/app/models/users/user_pick.rb
@@ -1,0 +1,3 @@
+class Users::UserPick < ApplicationRecord
+
+end

--- a/app/models/users/user_pick.rb
+++ b/app/models/users/user_pick.rb
@@ -1,3 +1,6 @@
-class Users::UserPick < ApplicationRecord
+# frozen_string_literal: true
 
+module Users
+  class UserPick < ApplicationRecord
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,6 +12,13 @@
       <% @user.calculate_total_points %>
       <%= @user.total_points %>
     </p>
+
+    <p>
+      <strong>Points from Last Race:</strong>
+      <%= @user.user_picks.sort.last.points_earned %>
+    </p>
+
+
     <%= button_to "View previous picks", user_user_picks_path(@user), method: :get %>
   </div> <!-- This ends the user scoring column -->
 
@@ -23,7 +30,7 @@
       <h2><%= @next_race[:raceName] %></h2>
     </div>
     <div> <!-- submit picks form -->
-      <h1>Submit Picks</h1>
+      <h1>Your Picks</h1>
       <%= form_with(model: UserPick.new, url: '/user_picks', method: :post) do |form| %>
         <%= form.hidden_field :circuit_id, value: @next_race[:Circuit][:circuitId] %> 
         <%= form.hidden_field :user_id, value: @user.id %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,10 +9,10 @@
 
     <p>
       <strong>Total points:</strong>
+      <% @user.calculate_total_points %>
       <%= @user.total_points %>
     </p>
-
-    <p> button to view previous picks table </p>
+    <%= button_to "View previous picks", user_user_picks_path(@user), method: :get %>
   </div> <!-- This ends the user scoring column -->
 
   <div class="flex flex-col"> <!-- This starts the user picks column -->

--- a/app/views/users/user_picks/index.html.erb
+++ b/app/views/users/user_picks/index.html.erb
@@ -11,12 +11,13 @@
       </tr>
     </thead>
     <tbody>
+    <% @user.user_picks.purify_pick_names %>
     <% @user.user_picks.each do |user_pick| %>
         <tr>
-          <td><%= user_pick.circuit_id %></td>
-          <td><%= user_pick.driver_id_tenth  %></td>
+          <td><%= user_pick.race_name %></td>
+          <td><%= user_pick.driver_id  %></td>
           <td><%= user_pick.tenth_finish_position %></td>
-          <td><%= user_pick.driver_id_dnf  %></td>
+          <td><%= user_pick.dnf_name  %></td>
           <% if user_pick.dnf_finish_position == ""%>
             <td>False</td>
           <% else %>

--- a/app/views/users/user_picks/index.html.erb
+++ b/app/views/users/user_picks/index.html.erb
@@ -1,0 +1,30 @@
+<div class="flex flex-row">
+  <table>
+    <thead>
+      <tr>
+        <th>Race</th>
+        <th>Driver Pick for 10th</th>
+        <th>Driver Finish Position</th>
+        <th>Driver Pick for First DNF</th>
+        <th>First DNF?</th>
+        <th>Points Earned</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @user.user_picks.each do |user_pick| %>
+        <tr>
+          <td><%= user_pick.circuit_id %></td>
+          <td><%= user_pick.driver_id_tenth  %></td>
+          <td><%= user_pick.tenth_finish_position %></td>
+          <td><%= user_pick.driver_id_dnf  %></td>
+          <% if user_pick.dnf_finish_position == ""%>
+            <td>False</td>
+          <% else %>
+            <td>True</td>
+          <% end %>
+          <td><%= user_pick.points_earned %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
 
   resources :user_picks
   resources :user_seasons
-  resources :users
+  resources :users do
+    resources :user_picks, only: [:index], controller: 'users/user_picks'
+  end
   resources :seasons
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20230728182356_add_race_name_and_dnf_name_to_user_picks.rb
+++ b/db/migrate/20230728182356_add_race_name_and_dnf_name_to_user_picks.rb
@@ -1,0 +1,6 @@
+class AddRaceNameAndDnfNameToUserPicks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_picks, :race_name, :string
+    add_column :user_picks, :dnf_name, :string
+  end
+end

--- a/db/migrate/20230728182356_add_race_name_and_dnf_name_to_user_picks.rb
+++ b/db/migrate/20230728182356_add_race_name_and_dnf_name_to_user_picks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRaceNameAndDnfNameToUserPicks < ActiveRecord::Migration[7.0]
   def change
     add_column :user_picks, :race_name, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,49 +12,49 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_182356) do
+ActiveRecord::Schema[7.0].define(version: 20_230_728_182_356) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "seasons", force: :cascade do |t|
-    t.string "season_year"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table 'seasons', force: :cascade do |t|
+    t.string 'season_year'
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
   end
 
-  create_table "user_picks", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "driver_id"
-    t.string "circuit_id"
-    t.integer "points_earned", default: 0
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.integer "tenth_finish_position", default: 0
-    t.string "driver_id_dnf"
-    t.string "driver_id_tenth", default: ""
-    t.string "dnf_finish_position"
-    t.string "race_name"
-    t.string "dnf_name"
-    t.index ["user_id"], name: "index_user_picks_on_user_id"
+  create_table 'user_picks', force: :cascade do |t|
+    t.bigint 'user_id'
+    t.string 'driver_id'
+    t.string 'circuit_id'
+    t.integer 'points_earned', default: 0
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
+    t.integer 'tenth_finish_position', default: 0
+    t.string 'driver_id_dnf'
+    t.string 'driver_id_tenth', default: ''
+    t.string 'dnf_finish_position'
+    t.string 'race_name'
+    t.string 'dnf_name'
+    t.index ['user_id'], name: 'index_user_picks_on_user_id'
   end
 
-  create_table "user_seasons", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "season_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["season_id"], name: "index_user_seasons_on_season_id"
-    t.index ["user_id"], name: "index_user_seasons_on_user_id"
+  create_table 'user_seasons', force: :cascade do |t|
+    t.bigint 'user_id'
+    t.bigint 'season_id'
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
+    t.index ['season_id'], name: 'index_user_seasons_on_season_id'
+    t.index ['user_id'], name: 'index_user_seasons_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.integer "total_points", default: 0
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table 'users', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'total_points', default: 0
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
   end
 
-  add_foreign_key "user_picks", "users"
-  add_foreign_key "user_seasons", "seasons"
-  add_foreign_key "user_seasons", "users"
+  add_foreign_key 'user_picks', 'users'
+  add_foreign_key 'user_seasons', 'seasons'
+  add_foreign_key 'user_seasons', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,47 +10,47 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_727_205_841) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_205841) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'seasons', force: :cascade do |t|
-    t.string 'season_year'
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'updated_at', precision: nil, null: false
+  create_table "seasons", force: :cascade do |t|
+    t.string "season_year"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table 'user_picks', force: :cascade do |t|
-    t.bigint 'user_id'
-    t.string 'driver_id'
-    t.string 'circuit_id'
-    t.integer 'points_earned', default: 0
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'updated_at', precision: nil, null: false
-    t.integer 'tenth_finish_position', default: 0
-    t.string 'driver_id_dnf'
-    t.string 'driver_id_tenth', default: ''
-    t.string 'dnf_finish_position'
-    t.index ['user_id'], name: 'index_user_picks_on_user_id'
+  create_table "user_picks", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "driver_id"
+    t.string "circuit_id"
+    t.integer "points_earned", default: 0
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "tenth_finish_position", default: 0
+    t.string "driver_id_dnf"
+    t.string "driver_id_tenth", default: ""
+    t.string "dnf_finish_position"
+    t.index ["user_id"], name: "index_user_picks_on_user_id"
   end
 
-  create_table 'user_seasons', force: :cascade do |t|
-    t.bigint 'user_id'
-    t.bigint 'season_id'
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'updated_at', precision: nil, null: false
-    t.index ['season_id'], name: 'index_user_seasons_on_season_id'
-    t.index ['user_id'], name: 'index_user_seasons_on_user_id'
+  create_table "user_seasons", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "season_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["season_id"], name: "index_user_seasons_on_season_id"
+    t.index ["user_id"], name: "index_user_seasons_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'total_points', default: 0
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'updated_at', precision: nil, null: false
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.integer "total_points", default: 0
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  add_foreign_key 'user_picks', 'users'
-  add_foreign_key 'user_seasons', 'seasons'
-  add_foreign_key 'user_seasons', 'users'
+  add_foreign_key "user_picks", "users"
+  add_foreign_key "user_seasons", "seasons"
+  add_foreign_key "user_seasons", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_205841) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_182356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_205841) do
     t.string "driver_id_dnf"
     t.string "driver_id_tenth", default: ""
     t.string "dnf_finish_position"
+    t.string "race_name"
+    t.string "dnf_name"
     t.index ["user_id"], name: "index_user_picks_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,3 +23,39 @@ UserSeason.create!(user_id: user3.id, season_id: season1.id)
 UserSeason.create!(user_id: user4.id, season_id: season1.id)
 UserSeason.create!(user_id: user5.id, season_id: season1.id)
 UserSeason.create!(user_id: user6.id, season_id: season1.id)
+
+UserPick.create!(user_id: user1.id, circuit_id: 'jeddah', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'albert_park', driver_id_dnf: 'sargeant',
+  driver_id_tenth: 'gasly', tenth_finish_position: 13, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'baku', driver_id_dnf: 'stroll',
+  driver_id_tenth: 'albon', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'miami', driver_id_dnf: 'norris',
+  driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'monaco', driver_id_dnf: 'gasly',
+  driver_id_tenth: 'tsunoda', tenth_finish_position: 15, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'catalunya', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'villeneuve', driver_id_dnf: 'hulkenberg',
+  driver_id_tenth: 'albon', tenth_finish_position: 7, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'alonso',
+  driver_id_tenth: 'albon', tenth_finish_position: 11, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'silverstone', driver_id_dnf: 'bottas',
+  driver_id_tenth: 'stroll', tenth_finish_position: 14, dnf_finish_position: '')
+
+UserPick.create!(user_id: user1.id, circuit_id: 'hungaroring', driver_id_dnf: 'max_verstappen',
+  driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
+
+UserPick.all.each do |pick|
+  pick.calculate_points
+  pick.dnf_points
+  user1.calculate_total_points
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,178 +26,176 @@ UserSeason.create!(user_id: user6.id, season_id: season1.id)
 
 # My Picks
 UserPick.create!(user_id: user1.id, circuit_id: 'jeddah', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
+                 driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'albert_park', driver_id_dnf: 'sargeant',
-  driver_id_tenth: 'gasly', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 13, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'baku', driver_id_dnf: 'stroll',
-  driver_id_tenth: 'albon', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'albon', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'miami', driver_id_dnf: 'norris',
-  driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'monaco', driver_id_dnf: 'gasly',
-  driver_id_tenth: 'tsunoda', tenth_finish_position: 15, dnf_finish_position: '')
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 15, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'catalunya', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'villeneuve', driver_id_dnf: 'hulkenberg',
-  driver_id_tenth: 'albon', tenth_finish_position: 7, dnf_finish_position: '')
+                 driver_id_tenth: 'albon', tenth_finish_position: 7, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'alonso',
-  driver_id_tenth: 'albon', tenth_finish_position: 11, dnf_finish_position: '')
+                 driver_id_tenth: 'albon', tenth_finish_position: 11, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'silverstone', driver_id_dnf: 'bottas',
-  driver_id_tenth: 'stroll', tenth_finish_position: 14, dnf_finish_position: '')
+                 driver_id_tenth: 'stroll', tenth_finish_position: 14, dnf_finish_position: '')
 
 UserPick.create!(user_id: user1.id, circuit_id: 'hungaroring', driver_id_dnf: 'max_verstappen',
-  driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
+                 driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
 
 # Chase's Picks
 UserPick.create!(user_id: user2.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
-  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'albert_park', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'norris', tenth_finish_position: 6, dnf_finish_position: '')
+                 driver_id_tenth: 'norris', tenth_finish_position: 6, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'baku', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'ocon', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'miami', driver_id_dnf: 'zhou',
-  driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'monaco', driver_id_dnf: 'stroll',
-  driver_id_tenth: 'norris', tenth_finish_position: 15, dnf_finish_position: 'R')
+                 driver_id_tenth: 'norris', tenth_finish_position: 15, dnf_finish_position: 'R')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'catalunya', driver_id_dnf: 'sainz',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'villeneuve', driver_id_dnf: 'perez',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'sargeant',
-  driver_id_tenth: 'stroll', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'stroll', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'silverstone', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'albon', tenth_finish_position: 8, dnf_finish_position: '')
+                 driver_id_tenth: 'albon', tenth_finish_position: 8, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'ricciardo',
-  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
-  
+                 driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
+
 # T's Picks
 UserPick.create!(user_id: user3.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
-  driver_id_tenth: 'zhou', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'zhou', tenth_finish_position: 13, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'albert_park', driver_id_dnf: 'norris',
-  driver_id_tenth: 'zhou', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'zhou', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'baku', driver_id_dnf: 'hulkenberg',
-  driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'miami', driver_id_dnf: 'leclerc',
-  driver_id_tenth: 'hamilton', tenth_finish_position: 6, dnf_finish_position: '')
+                 driver_id_tenth: 'hamilton', tenth_finish_position: 6, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'monaco', driver_id_dnf: 'albon',
-  driver_id_tenth: 'russell', tenth_finish_position: 5, dnf_finish_position: '')
+                 driver_id_tenth: 'russell', tenth_finish_position: 5, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'catalunya', driver_id_dnf: 'norris',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'villeneuve', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'bottas',
-  driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'silverstone', driver_id_dnf: 'stroll',
-  driver_id_tenth: 'ocon', tenth_finish_position: 20, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 20, dnf_finish_position: '')
 
 UserPick.create!(user_id: user3.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
 
 # Steph's Picks
 UserPick.create!(user_id: user4.id, circuit_id: 'jeddah', driver_id_dnf: 'sainz',
-  driver_id_tenth: 'gasly', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'albert_park', driver_id_dnf: 'norris',
-  driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'baku', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'norris', tenth_finish_position: 9, dnf_finish_position: '')
+                 driver_id_tenth: 'norris', tenth_finish_position: 9, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'miami', driver_id_dnf: 'leclerc',
-  driver_id_tenth: 'albon', tenth_finish_position: 14, dnf_finish_position: '')
+                 driver_id_tenth: 'albon', tenth_finish_position: 14, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'monaco', driver_id_dnf: 'sargeant',
-  driver_id_tenth: 'piastri', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'piastri', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'catalunya', driver_id_dnf: 'stroll',
-  driver_id_tenth: 'piastri', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'piastri', tenth_finish_position: 13, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'villeneuve', driver_id_dnf: 'zhou',
-  driver_id_tenth: 'piastri', tenth_finish_position: 11, dnf_finish_position: '')
+                 driver_id_tenth: 'piastri', tenth_finish_position: 11, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'bottas',
-  driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'silverstone', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'hungaroring', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
-
+                 driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
 
 # Eric's Picks
 UserPick.create!(user_id: user5.id, circuit_id: 'jeddah', driver_id_dnf: 'gasly',
-  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'albert_park', driver_id_dnf: 'de_vries',
-  driver_id_tenth: 'perez', tenth_finish_position: 5, dnf_finish_position: '')
+                 driver_id_tenth: 'perez', tenth_finish_position: 5, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'baku', driver_id_dnf: 'leclerc',
-  driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
+                 driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'miami', driver_id_dnf: 'zhou',
-  driver_id_tenth: 'magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'magnussen', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'monaco', driver_id_dnf: 'leclerc',
-  driver_id_tenth: 'ocon', tenth_finish_position: 3, dnf_finish_position: '')
+                 driver_id_tenth: 'ocon', tenth_finish_position: 3, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'catalunya', driver_id_dnf: 'hulkenberg',
-  driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'villeneuve', driver_id_dnf: 'bottas',
-  driver_id_tenth: 'norris', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'norris', tenth_finish_position: 13, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 20, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 20, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'silverstone', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 13, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 13, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
-  driver_id_tenth: 'hulkenberg', tenth_finish_position: 14, dnf_finish_position: '')
+                 driver_id_tenth: 'hulkenberg', tenth_finish_position: 14, dnf_finish_position: '')
 
 # Camden's Picks
 UserPick.create!(user_id: user6.id, circuit_id: 'catalunya', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'gasly', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user6.id, circuit_id: 'villeneuve', driver_id_dnf: 'stroll',
-  driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
 
 UserPick.create!(user_id: user6.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'kevin_magnussen',
-  driver_id_tenth: 'perez', tenth_finish_position: 3, dnf_finish_position: '')
+                 driver_id_tenth: 'perez', tenth_finish_position: 3, dnf_finish_position: '')
 
 UserPick.create!(user_id: user6.id, circuit_id: 'silverstone', driver_id_dnf: 'de_vries',
-  driver_id_tenth: 'gasly', tenth_finish_position: 18, dnf_finish_position: '')
+                 driver_id_tenth: 'gasly', tenth_finish_position: 18, dnf_finish_position: '')
 
 UserPick.create!(user_id: user6.id, circuit_id: 'hungaroring', driver_id_dnf: 'hulkenberg',
-  driver_id_tenth: 'hamilton', tenth_finish_position: 4, dnf_finish_position: '')
+                 driver_id_tenth: 'hamilton', tenth_finish_position: 4, dnf_finish_position: '')
 
-
-  UserPick.all.each do |pick|
+UserPick.all.each do |pick|
   pick.calculate_points
   pick.dnf_points
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,7 @@ UserSeason.create!(user_id: user4.id, season_id: season1.id)
 UserSeason.create!(user_id: user5.id, season_id: season1.id)
 UserSeason.create!(user_id: user6.id, season_id: season1.id)
 
+# My Picks
 UserPick.create!(user_id: user1.id, circuit_id: 'jeddah', driver_id_dnf: 'piastri',
   driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
 
@@ -54,8 +55,156 @@ UserPick.create!(user_id: user1.id, circuit_id: 'silverstone', driver_id_dnf: 'b
 UserPick.create!(user_id: user1.id, circuit_id: 'hungaroring', driver_id_dnf: 'max_verstappen',
   driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
 
-UserPick.all.each do |pick|
+# Chase's Picks
+UserPick.create!(user_id: user2.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
+  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'albert_park', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'norris', tenth_finish_position: 6, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'baku', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'ocon', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'miami', driver_id_dnf: 'zhou',
+  driver_id_tenth: 'ocon', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'monaco', driver_id_dnf: 'stroll',
+  driver_id_tenth: 'norris', tenth_finish_position: 15, dnf_finish_position: 'R')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'catalunya', driver_id_dnf: 'sainz',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'villeneuve', driver_id_dnf: 'perez',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'sargeant',
+  driver_id_tenth: 'stroll', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'silverstone', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'albon', tenth_finish_position: 8, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'ricciardo',
+  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
+  
+# T's Picks
+UserPick.create!(user_id: user3.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
+  driver_id_tenth: 'zhou', tenth_finish_position: 13, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'albert_park', driver_id_dnf: 'norris',
+  driver_id_tenth: 'zhou', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'baku', driver_id_dnf: 'hulkenberg',
+  driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'miami', driver_id_dnf: 'leclerc',
+  driver_id_tenth: 'hamilton', tenth_finish_position: 6, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'monaco', driver_id_dnf: 'albon',
+  driver_id_tenth: 'russell', tenth_finish_position: 5, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'catalunya', driver_id_dnf: 'norris',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 15, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'villeneuve', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'bottas',
+  driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'silverstone', driver_id_dnf: 'stroll',
+  driver_id_tenth: 'ocon', tenth_finish_position: 20, dnf_finish_position: '')
+
+UserPick.create!(user_id: user3.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
+
+# Steph's Picks
+UserPick.create!(user_id: user4.id, circuit_id: 'jeddah', driver_id_dnf: 'sainz',
+  driver_id_tenth: 'gasly', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'albert_park', driver_id_dnf: 'norris',
+  driver_id_tenth: 'tsunoda', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'baku', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'norris', tenth_finish_position: 9, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'miami', driver_id_dnf: 'leclerc',
+  driver_id_tenth: 'albon', tenth_finish_position: 14, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'monaco', driver_id_dnf: 'sargeant',
+  driver_id_tenth: 'piastri', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'catalunya', driver_id_dnf: 'stroll',
+  driver_id_tenth: 'piastri', tenth_finish_position: 13, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'villeneuve', driver_id_dnf: 'zhou',
+  driver_id_tenth: 'piastri', tenth_finish_position: 11, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'bottas',
+  driver_id_tenth: 'ocon', tenth_finish_position: 14, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'silverstone', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'hungaroring', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
+
+
+# Eric's Picks
+UserPick.create!(user_id: user5.id, circuit_id: 'jeddah', driver_id_dnf: 'gasly',
+  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'albert_park', driver_id_dnf: 'de_vries',
+  driver_id_tenth: 'perez', tenth_finish_position: 5, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'baku', driver_id_dnf: 'leclerc',
+  driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'miami', driver_id_dnf: 'zhou',
+  driver_id_tenth: 'magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'monaco', driver_id_dnf: 'leclerc',
+  driver_id_tenth: 'ocon', tenth_finish_position: 3, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'catalunya', driver_id_dnf: 'hulkenberg',
+  driver_id_tenth: 'tsunoda', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'villeneuve', driver_id_dnf: 'bottas',
+  driver_id_tenth: 'norris', tenth_finish_position: 13, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 20, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'silverstone', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 13, dnf_finish_position: '')
+
+UserPick.create!(user_id: user5.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
+  driver_id_tenth: 'hulkenberg', tenth_finish_position: 14, dnf_finish_position: '')
+
+# Camden's Picks
+UserPick.create!(user_id: user6.id, circuit_id: 'catalunya', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'gasly', tenth_finish_position: 10, dnf_finish_position: '')
+
+UserPick.create!(user_id: user6.id, circuit_id: 'villeneuve', driver_id_dnf: 'stroll',
+  driver_id_tenth: 'gasly', tenth_finish_position: 12, dnf_finish_position: '')
+
+UserPick.create!(user_id: user6.id, circuit_id: 'red_bull_ring', driver_id_dnf: 'kevin_magnussen',
+  driver_id_tenth: 'perez', tenth_finish_position: 3, dnf_finish_position: '')
+
+UserPick.create!(user_id: user6.id, circuit_id: 'silverstone', driver_id_dnf: 'de_vries',
+  driver_id_tenth: 'gasly', tenth_finish_position: 18, dnf_finish_position: '')
+
+UserPick.create!(user_id: user6.id, circuit_id: 'hungaroring', driver_id_dnf: 'hulkenberg',
+  driver_id_tenth: 'hamilton', tenth_finish_position: 4, dnf_finish_position: '')
+
+
+  UserPick.all.each do |pick|
   pick.calculate_points
   pick.dnf_points
-  user1.calculate_total_points
 end
+
+user1.calculate_total_points
+user2.calculate_total_points
+user3.calculate_total_points
+user4.calculate_total_points
+user5.calculate_total_points
+user6.calculate_total_points

--- a/spec/service/f1_service_spec.rb
+++ b/spec/service/f1_service_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe F1Service do
   end
 
   it 'returns the latest qualifying results', vcr: { record: :new_episodes } do
-    season = "2023"
-    round = "1"
+    season = '2023'
+    round = '1'
     response = F1Service.new.get_qualifying(season, round)
 
     expect(response).to be_a(Hash)


### PR DESCRIPTION
This PR adds the User's previous picks page
- Current tests passing at 97.76% coverage

1. chore: add index method to user_picks controller
2. chore: `purify_pick_names` method
3. chore: adjust routes for user/user_picks
4. chore: add new columns to the user_picks table
5. chore: add seeds for existing picks from earlier in the season
6. feat: add points from last race to user show page
7. feat: create the table for previous picks on the user/user_picks show page
8. refactor: rubocop fixes