### PR TITLE
Add and format time on season dashboard

### DIFF
--- a/app/models/user_pick.rb
+++ b/app/models/user_pick.rb
@@ -105,4 +105,59 @@ class UserPick < ApplicationRecord
       pick.update(dnf_name: driver_names[pick.driver_id_dnf.to_s])
     end
   end
+
+  def purify_single_pick
+    driver_names = {
+      'albon' => 'Alexander Albon',
+      'alonso' => 'Fernando Alonso',
+      'bottas' => 'Valtteri Bottas',
+      'de_vries' => 'Nyck de Vries',
+      'gasly' => 'Pierre Gasly',
+      'hamilton' => 'Lewis Hamilton',
+      'hulkenberg' => 'Nico Hülkenberg',
+      'leclerc' => 'Charles Leclerc',
+      'kevin_magnussen' => 'Kevin Magnussen',
+      'norris' => 'Lando Norris',
+      'ocon' => 'Esteban Ocon',
+      'perez' => 'Sergio Pérez',
+      'piastri' => 'Oscar Piastri',
+      'ricciardo' => 'Daniel Ricciardo',
+      'russell' => 'George Russell',
+      'sainz' => 'Carlos Sainz',
+      'sargeant' => 'Logan Sargeant',
+      'stroll' => 'Lance Stroll',
+      'tsunoda' => 'Yuki Tsunoda',
+      'max_verstappen' => 'Max Verstappen',
+      'zhou' => 'Guanyu Zhou'
+    }
+
+    track_names = {
+      'bahrain' => 'Bahrain Grand Prix',
+      'jeddah' => 'Saudi Arabian Grand Prix',
+      'albert_park' => 'Australian Grand Prix',
+      'baku' => 'Azerbaijan Grand Prix',
+      'miami' => 'Miami Grand Prix',
+      'monaco' => 'Monaco Grand Prix',
+      'catalunya' => 'Spanish Grand Prix',
+      'villeneuve' => 'Canadian Grand Prix',
+      'red_bull_ring' => 'Austrian Grand Prix',
+      'silverstone' => 'British Grand Prix',
+      'hungaroring' => 'Hungarian Grand Prix',
+      'spa' => 'Belgian Grand Prix',
+      'zandvoort' => 'Dutch Grand Prix',
+      'monza' => 'Italian Grand Prix',
+      'marina_bay' => 'Singapore Grand Prix',
+      'suzuka' => 'Japanese Grand Prix',
+      'losail' => 'Qatar Grand Prix',
+      'americas' => 'United States Grand Prix',
+      'rodriguez' => 'Mexico City Grand Prix',
+      'interlagos' => 'São Paulo Grand Prix',
+      'vegas' => 'Las Vegas Grand Prix',
+      'yas_marina' => 'Abu Dhabi Grand Prix'
+    }
+
+      self.update(driver_id: driver_names[self.driver_id_tenth.to_s])
+      self.update(race_name: track_names[self.circuit_id.to_s])
+      self.update(dnf_name: driver_names[self.driver_id_dnf.to_s])
+  end
 end

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -69,6 +69,7 @@
 
   <div class="flex flex-col"> <!-- This starts the next and previous race weekend section -->
     <br>
+    
     <% if @next_race %>
       <h2>Next Race: <%= @next_race[:raceName] %></h2>
       <br>
@@ -76,18 +77,18 @@
       <br>
       <h3>Dates:</h3>
       <br>
-      <h4>Race: <%= @next_race[:date].to_date.strftime('%m-%d-%Y') %> </h4>
+      <h4>Race: <%= @next_race[:date].to_date.strftime('%B %d') %>: <%= @next_race[:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %> </h4>
       <br>
       <% if @next_race[:ThirdPractice] %>
-        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Free Practice 2: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Free Practice 3: <%=  @next_race[:ThirdPractice][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%m-%d-%Y') %></p>
+        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%B %d') %></p>
+        <p>Free Practice 2: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%B %d') %></p>
+        <p>Free Practice 3: <%=  @next_race[:ThirdPractice][:date].to_date.strftime('%B %d') %></p>
+        <p>Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%B %d') %></p>
       <% else %>
-        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Race Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Sprint Shootout: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%m-%d-%Y') %></p>
-        <p>Sprint: <%=  @next_race[:Sprint][:date].to_date.strftime('%m-%d-%Y') %></p>
+        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%B %d') %>: <%= @next_race[:FirstPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Race Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%B %d') %>: <%= @next_race[:Qualifying][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Sprint Shootout: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%B %d') %>: <%= @next_race[:SecondPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Sprint: <%=  @next_race[:Sprint][:date].to_date.strftime('%B %d') %>: <%= @next_race[:Sprint][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
       <% end %>
     <% else %>
       <h2> No Next Race Weekend Scheduled</h2>
@@ -98,7 +99,7 @@
     <br>
     <h3>Circuit: <%= @last_race[:Circuit][:circuitName] %></h3>
     <br>
-    <h3>Race Date: <%= @last_race[:date].to_date.strftime('%m-%d-%Y') %></h3>
+    <h3>Race Date: <%= @last_race[:date].to_date.strftime('%B %d') %></h3>
     <br>
     <h3>Podium</h3>
     <ol>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -67,9 +67,8 @@
     </div> <!-- This ends the constructor standings -->
   </div> <!-- This ends the column -->
 
-  <div class="flex flex-col"> <!-- This starts the next and previous race weekend section -->
+  <div class="flex flex-col font-serif"> <!-- This starts the next and previous race weekend section -->
     <br>
-    
     <% if @next_race %>
       <h2>Next Race: <%= @next_race[:raceName] %></h2>
       <br>

--- a/app/views/user_picks/show.html.erb
+++ b/app/views/user_picks/show.html.erb
@@ -1,24 +1,27 @@
 <p id="notice"><%= notice %></p>
 
+<% @user_pick.purify_single_pick %>
+
 <p>
   <strong>User:</strong>
-  <%= @user_pick.user %>
+  <%= @user_pick.user.name %>
 </p>
 
 <p>
-  <strong>Driver:</strong>
+  <strong>Race Name:</strong>
+  <%= @user_pick.race_name %>
+</p>
+
+<p>
+  <strong>10th Driver:</strong>
   <%= @user_pick.driver_id %>
 </p>
 
 <p>
-  <strong>Circuit:</strong>
-  <%= @user_pick.circuit_id %>
+  <strong>DNF Driver:</strong>
+  <%= @user_pick.dnf_name %>
 </p>
 
-<p>
-  <strong>Points earned:</strong>
-  <%= @user_pick.points_earned %>
-</p>
 
 <%= link_to 'Edit', edit_user_pick_path(@user_pick) %> |
 <%= link_to 'Back', user_picks_path %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 20_230_728_182_356) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_182356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,21 +20,20 @@ ActiveRecord::Schema[7.0].define(version: 20_230_728_182_356) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-
-  create_table 'user_picks', force: :cascade do |t|
-    t.bigint 'user_id'
-    t.string 'driver_id'
-    t.string 'circuit_id'
-    t.integer 'points_earned', default: 0
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'updated_at', precision: nil, null: false
-    t.integer 'tenth_finish_position', default: 0
-    t.string 'driver_id_dnf'
-    t.string 'driver_id_tenth', default: ''
-    t.string 'dnf_finish_position'
-    t.string 'race_name'
-    t.string 'dnf_name'
-    t.index ['user_id'], name: 'index_user_picks_on_user_id'
+  create_table "user_picks", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "driver_id"
+    t.string "circuit_id"
+    t.integer "points_earned", default: 0
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "tenth_finish_position", default: 0
+    t.string "driver_id_dnf"
+    t.string "driver_id_tenth", default: ""
+    t.string "dnf_finish_position"
+    t.string "race_name"
+    t.string "dnf_name"
+    t.index ["user_id"], name: "index_user_picks_on_user_id"
   end
 
   create_table "user_seasons", force: :cascade do |t|


### PR DESCRIPTION
This PR adds formatted race time to the season show page
- Tests currently passing at 96.77%

1. chore: bring over purify pick method for a single user pick
2. feat: add times to season#show
3. refactor: user_pick#show