### PR TITLE
Fix points

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,15 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+# API gems
 gem 'faraday'
-
 gem 'net-http'
 
+# Styling
 gem 'tailwindcss-rails'
 
+# Time-related
+gem 'timecop'
+
+# Miscelaneous
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,7 @@ GEM
       railties (>= 6.0.0)
     thor (1.2.2)
     tilt (2.2.0)
+    timecop (0.9.6)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -329,6 +330,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   tailwindcss-rails
+  timecop
   tzinfo-data
   uglifier (>= 1.3.0)
   vcr

--- a/app/controllers/leaderboard_controller.rb
+++ b/app/controllers/leaderboard_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LeaderboardController < ApplicationController
   def index
     @users = User.order(total_points: :desc)

--- a/app/controllers/user_picks_controller.rb
+++ b/app/controllers/user_picks_controller.rb
@@ -6,6 +6,7 @@ class UserPicksController < ApplicationController
   # GET /user_picks or /user_picks.json
   def index
     @user_picks = UserPick.all
+    @last_6 = UserPick.last(6)
   end
 
   # GET /user_picks/1 or /user_picks/1.json

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -7,8 +7,6 @@ class Season < ApplicationRecord
   has_many :users, through: :user_seasons
 
   def next_race_weekend
-    # schedule = F1Facade.new.get_schedule(season_year)
-    # next_race = schedule.where('date > ?', Date.today).first
     schedule = F1Facade.new.get_schedule(season_year)
     race_array = schedule[:MRData][:RaceTable][:Races]
     race_array.select { |race| Date.parse(race[:date]) > Date.today }.first

--- a/app/models/user_pick.rb
+++ b/app/models/user_pick.rb
@@ -155,8 +155,8 @@ class UserPick < ApplicationRecord
       'yas_marina' => 'Abu Dhabi Grand Prix'
     }
 
-      self.update(driver_id: driver_names[self.driver_id_tenth.to_s])
-      self.update(race_name: track_names[self.circuit_id.to_s])
-      self.update(dnf_name: driver_names[self.driver_id_dnf.to_s])
+    update(driver_id: driver_names[driver_id_tenth.to_s])
+    update(race_name: track_names[circuit_id.to_s])
+    update(dnf_name: driver_names[driver_id_dnf.to_s])
   end
 end

--- a/app/models/user_pick.rb
+++ b/app/models/user_pick.rb
@@ -29,7 +29,6 @@ class UserPick < ApplicationRecord
     return unless circuit_id == finish[:MRData][:RaceTable][:Races][0][:Circuit][:circuitId]
 
     finish[:MRData][:RaceTable][:Races][0][:Results].each do |result|
-      # require 'pry'; binding.pry
       if driver_id_dnf == result[:Driver][:driverId] && result[:positionText] == 'R' && result[:position] == '20'
         update(dnf_finish_position: result[:positionText])
       end

--- a/app/service/f1_service.rb
+++ b/app/service/f1_service.rb
@@ -2,11 +2,11 @@
 
 class F1Service
   def get_drivers(driver_season)
-      get_url("/api/f1/#{driver_season}/drivers.json")
+    get_url("/api/f1/#{driver_season}/drivers.json")
   end
 
   def get_result(race_season, round)
-      get_url("/api/f1/#{race_season}/#{round}/results.json")
+    get_url("/api/f1/#{race_season}/#{round}/results.json")
   end
 
   def get_constructors(constructors_season)

--- a/app/service/f1_service.rb
+++ b/app/service/f1_service.rb
@@ -2,21 +2,15 @@
 
 class F1Service
   def get_drivers(driver_season)
-    Rails.cache.fetch([driver_season], expires: 1.week) do
       get_url("/api/f1/#{driver_season}/drivers.json")
-    end
   end
 
   def get_result(race_season, round)
-    Rails.cache.fetch([race_season, round], expires: 1.week) do
       get_url("/api/f1/#{race_season}/#{round}/results.json")
-    end
   end
 
   def get_constructors(constructors_season)
-    # Rails.cache.fetch([constructors_season], expires: 1.week) do
     get_url("/api/f1/#{constructors_season}/constructors.json")
-    # end
   end
 
   def get_schedule(season)

--- a/app/views/leaderboard/index.html.erb
+++ b/app/views/leaderboard/index.html.erb
@@ -11,6 +11,7 @@
       </thead>
       <tbody>
         <% @users.each do |user| %>
+          <% user.calculate_total_points %>
           <tr>
             <td class="pr-4 text-center"><%= @position %></td>
             <td class="pr-4 text-center"><%= user.name %></td>
@@ -21,8 +22,6 @@
       </tbody>
     </table>
   </div> <!-- this ends the user-standings-table -->
-  
-  
 
 
   <div class="flex felx-col">

--- a/app/views/user_picks/index.html.erb
+++ b/app/views/user_picks/index.html.erb
@@ -1,6 +1,13 @@
 <p id="notice"><%= notice %></p>
 
 <h1>User Picks</h1>
+<% @last_6.each do |pick| %>
+  <% if pick.points_earned == 0  %>
+    <%= pick.assign_finish_position %>
+    <%= pick.calculate_points %>
+    <%= pick.dnf_points %>
+  <% end %>
+<% end %>
 
 <table>
   <thead>
@@ -13,7 +20,6 @@
       <th colspan="3"></th>
     </tr>
   </thead>
-
   <tbody>
   <% UserPick.all.purify_pick_names %>
     <% @user_picks.each do |user_pick| %>
@@ -24,7 +30,6 @@
         <td><%= user_pick.race_name %></td>
         <td><%= user_pick.points_earned %></td>
         <td><%= link_to 'Show', user_pick %></td>
-        <td><%= link_to 'Edit', edit_user_pick_path(user_pick) %></td>
         <td><%= button_to 'Destroy', user_pick_path(user_pick), method: :delete %></td>
       </tr>
     <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,49 +12,49 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_182356) do
+ActiveRecord::Schema[7.0].define(version: 20_230_728_182_356) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "seasons", force: :cascade do |t|
-    t.string "season_year"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table 'seasons', force: :cascade do |t|
+    t.string 'season_year'
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
   end
 
-  create_table "user_picks", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "driver_id"
-    t.string "circuit_id"
-    t.integer "points_earned", default: 0
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.integer "tenth_finish_position", default: 0
-    t.string "driver_id_dnf"
-    t.string "driver_id_tenth", default: ""
-    t.string "dnf_finish_position"
-    t.string "race_name"
-    t.string "dnf_name"
-    t.index ["user_id"], name: "index_user_picks_on_user_id"
+  create_table 'user_picks', force: :cascade do |t|
+    t.bigint 'user_id'
+    t.string 'driver_id'
+    t.string 'circuit_id'
+    t.integer 'points_earned', default: 0
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
+    t.integer 'tenth_finish_position', default: 0
+    t.string 'driver_id_dnf'
+    t.string 'driver_id_tenth', default: ''
+    t.string 'dnf_finish_position'
+    t.string 'race_name'
+    t.string 'dnf_name'
+    t.index ['user_id'], name: 'index_user_picks_on_user_id'
   end
 
-  create_table "user_seasons", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "season_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["season_id"], name: "index_user_seasons_on_season_id"
-    t.index ["user_id"], name: "index_user_seasons_on_user_id"
+  create_table 'user_seasons', force: :cascade do |t|
+    t.bigint 'user_id'
+    t.bigint 'season_id'
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
+    t.index ['season_id'], name: 'index_user_seasons_on_season_id'
+    t.index ['user_id'], name: 'index_user_seasons_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.integer "total_points", default: 0
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table 'users', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'total_points', default: 0
+    t.datetime 'created_at', precision: nil, null: false
+    t.datetime 'updated_at', precision: nil, null: false
   end
 
-  add_foreign_key "user_picks", "users"
-  add_foreign_key "user_seasons", "seasons"
-  add_foreign_key "user_seasons", "users"
+  add_foreign_key 'user_picks', 'users'
+  add_foreign_key 'user_seasons', 'seasons'
+  add_foreign_key 'user_seasons', 'users'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,8 +55,6 @@ UserPick.create!(user_id: user1.id, circuit_id: 'silverstone', driver_id_dnf: 'b
 UserPick.create!(user_id: user1.id, circuit_id: 'hungaroring', driver_id_dnf: 'max_verstappen',
                  driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
 
-
-
 # Chase's Picks
 UserPick.create!(user_id: user2.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
                  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
@@ -87,7 +85,6 @@ UserPick.create!(user_id: user2.id, circuit_id: 'silverstone', driver_id_dnf: 'p
 
 UserPick.create!(user_id: user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'ricciardo',
                  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
-               
 
 # T's Picks
 UserPick.create!(user_id: user3.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
@@ -119,8 +116,6 @@ UserPick.create!(user_id: user3.id, circuit_id: 'silverstone', driver_id_dnf: 's
 
 UserPick.create!(user_id: user3.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
                  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
-
-                  
 
 # Steph's Picks
 UserPick.create!(user_id: user4.id, circuit_id: 'jeddah', driver_id_dnf: 'sainz',
@@ -206,20 +201,19 @@ UserPick.create!(user_id: user1.id, circuit_id: 'spa', driver_id_dnf: 'sargeant'
                  driver_id_tenth: 'albon', tenth_finish_position: 0, dnf_finish_position: '')
 
 UserPick.create!(user_id: user2.id, circuit_id: 'spa', driver_id_dnf: 'gasly',
-                 driver_id_tenth: 'stroll', tenth_finish_position: 0, dnf_finish_position: '') 
-                 
+                 driver_id_tenth: 'stroll', tenth_finish_position: 0, dnf_finish_position: '')
+
 UserPick.create!(user_id: user3.id, circuit_id: 'spa', driver_id_dnf: 'leclerc',
                  driver_id_tenth: 'gasly', tenth_finish_position: 0, dnf_finish_position: '')
 
 UserPick.create!(user_id: user4.id, circuit_id: 'spa', driver_id_dnf: 'albon',
                  driver_id_tenth: 'tsunoda', tenth_finish_position: 0, dnf_finish_position: '')
-                 
+
 UserPick.create!(user_id: user5.id, circuit_id: 'spa', driver_id_dnf: 'gasly',
                  driver_id_tenth: 'bottas', tenth_finish_position: 0, dnf_finish_position: '')
-                 
-UserPick.create!(user_id: user6.id, circuit_id: 'spa', driver_id_dnf: 'alonso',
-                  driver_id_tenth: 'ricciardo', tenth_finish_position: 0, dnf_finish_position: '')
 
+UserPick.create!(user_id: user6.id, circuit_id: 'spa', driver_id_dnf: 'alonso',
+                 driver_id_tenth: 'ricciardo', tenth_finish_position: 0, dnf_finish_position: '')
 
 UserPick.all.each do |pick|
   pick.calculate_points

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,6 +55,8 @@ UserPick.create!(user_id: user1.id, circuit_id: 'silverstone', driver_id_dnf: 'b
 UserPick.create!(user_id: user1.id, circuit_id: 'hungaroring', driver_id_dnf: 'max_verstappen',
                  driver_id_tenth: 'russell', tenth_finish_position: 6, dnf_finish_position: '')
 
+
+
 # Chase's Picks
 UserPick.create!(user_id: user2.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
                  driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
@@ -85,6 +87,7 @@ UserPick.create!(user_id: user2.id, circuit_id: 'silverstone', driver_id_dnf: 'p
 
 UserPick.create!(user_id: user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'ricciardo',
                  driver_id_tenth: 'bottas', tenth_finish_position: 12, dnf_finish_position: '')
+               
 
 # T's Picks
 UserPick.create!(user_id: user3.id, circuit_id: 'jeddah', driver_id_dnf: 'max_verstappen',
@@ -116,6 +119,8 @@ UserPick.create!(user_id: user3.id, circuit_id: 'silverstone', driver_id_dnf: 's
 
 UserPick.create!(user_id: user3.id, circuit_id: 'hungaroring', driver_id_dnf: 'piastri',
                  driver_id_tenth: 'ricciardo', tenth_finish_position: 13, dnf_finish_position: '')
+
+                  
 
 # Steph's Picks
 UserPick.create!(user_id: user4.id, circuit_id: 'jeddah', driver_id_dnf: 'sainz',
@@ -159,7 +164,7 @@ UserPick.create!(user_id: user5.id, circuit_id: 'baku', driver_id_dnf: 'leclerc'
                  driver_id_tenth: 'bottas', tenth_finish_position: 18, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'miami', driver_id_dnf: 'zhou',
-                 driver_id_tenth: 'magnussen', tenth_finish_position: 10, dnf_finish_position: '')
+                 driver_id_tenth: 'kevin_magnussen', tenth_finish_position: 10, dnf_finish_position: '')
 
 UserPick.create!(user_id: user5.id, circuit_id: 'monaco', driver_id_dnf: 'leclerc',
                  driver_id_tenth: 'ocon', tenth_finish_position: 3, dnf_finish_position: '')
@@ -194,6 +199,27 @@ UserPick.create!(user_id: user6.id, circuit_id: 'silverstone', driver_id_dnf: 'd
 
 UserPick.create!(user_id: user6.id, circuit_id: 'hungaroring', driver_id_dnf: 'hulkenberg',
                  driver_id_tenth: 'hamilton', tenth_finish_position: 4, dnf_finish_position: '')
+
+# Belgian GP Picks
+
+UserPick.create!(user_id: user1.id, circuit_id: 'spa', driver_id_dnf: 'sargeant',
+                 driver_id_tenth: 'albon', tenth_finish_position: 0, dnf_finish_position: '')
+
+UserPick.create!(user_id: user2.id, circuit_id: 'spa', driver_id_dnf: 'gasly',
+                 driver_id_tenth: 'stroll', tenth_finish_position: 0, dnf_finish_position: '') 
+                 
+UserPick.create!(user_id: user3.id, circuit_id: 'spa', driver_id_dnf: 'leclerc',
+                 driver_id_tenth: 'gasly', tenth_finish_position: 0, dnf_finish_position: '')
+
+UserPick.create!(user_id: user4.id, circuit_id: 'spa', driver_id_dnf: 'albon',
+                 driver_id_tenth: 'tsunoda', tenth_finish_position: 0, dnf_finish_position: '')
+                 
+UserPick.create!(user_id: user5.id, circuit_id: 'spa', driver_id_dnf: 'gasly',
+                 driver_id_tenth: 'bottas', tenth_finish_position: 0, dnf_finish_position: '')
+                 
+UserPick.create!(user_id: user6.id, circuit_id: 'spa', driver_id_dnf: 'alonso',
+                  driver_id_tenth: 'ricciardo', tenth_finish_position: 0, dnf_finish_position: '')
+
 
 UserPick.all.each do |pick|
   pick.calculate_points

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -10,14 +10,33 @@ RSpec.describe Season, vcr: { record: :new_episodes }, type: :model do
     it { should validate_uniqueness_of(:season_year) }
   end
 
-  describe 'instance methods' do
+  describe 'model methods' do
+    before(:each) do
+      @user = User.create!(name: 'Bob', total_points: 0)
+      @user2 = User.create!(name: 'Joe', total_points: 0)
+      @season = Season.create!(season_year: 2023)
+      @schedule = F1Facade.new.get_schedule(@season.season_year)
+      UserSeason.create!(user_id: @user.id, season_id: @season.id)
+      UserSeason.create!(user_id: @user2.id, season_id: @season.id)
+    end
+
     it 'can get the next race weekend' do
-      season = Season.create!(season_year: 2023)
-      schedule = F1Facade.new.get_schedule(season.season_year)
-      race_array = schedule[:MRData][:RaceTable][:Races]
+      race_array = @schedule[:MRData][:RaceTable][:Races]
       next_race = race_array.select { |race| Date.parse(race[:date]) > Date.today }.first
 
-      expect(season.next_race_weekend).to eq(next_race)
+      expect(@season.next_race_weekend).to eq(next_race)
+    end
+
+    it 'can can get the last race weekend' do
+      fixed_date = '2023-07-30'
+      Timecop.freeze(fixed_date)
+
+      actual_last_race = 'Belgian Grand Prix'
+      actual_last_race_id = 'spa'
+      last_race = @season.last_race_weekend
+
+      expect(last_race[:raceName]).to eq('Belgian Grand Prix')
+      expect(last_race[:Circuit][:circuitId]).to eq('spa')
     end
   end
 end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -30,9 +30,6 @@ RSpec.describe Season, vcr: { record: :new_episodes }, type: :model do
     it 'can can get the last race weekend' do
       fixed_date = '2023-07-30'
       Timecop.freeze(fixed_date)
-
-      actual_last_race = 'Belgian Grand Prix'
-      actual_last_race_id = 'spa'
       last_race = @season.last_race_weekend
 
       expect(last_race[:raceName]).to eq('Belgian Grand Prix')

--- a/spec/models/user_pick_spec.rb
+++ b/spec/models/user_pick_spec.rb
@@ -89,5 +89,17 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
       expect(@pick2.race_name).to eq('Monaco Grand Prix')
       expect(@pick2.dnf_name).to eq('Daniel Ricciardo')
     end
+
+    it 'updates driver and track names for a single UserPick' do
+      @pick1 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'leclerc', circuit_id: 'spa', driver_id_dnf: 'ocon')
+
+      @pick1.purify_single_pick
+
+      @pick1.reload
+
+      expect(@pick1.driver_id).to eq('Charles Leclerc')
+      expect(@pick1.race_name).to eq('Belgian Grand Prix')
+      expect(@pick1.dnf_name).to eq('Esteban Ocon')
+    end
   end
 end

--- a/spec/models/user_pick_spec.rb
+++ b/spec/models/user_pick_spec.rb
@@ -68,8 +68,26 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
       fixed_date = '2023-07-30'
       Timecop.freeze(fixed_date)
 
-      current_race = @user_pick.set_cburrent_race
+      current_race = @user_pick.set_current_race
       expect(current_race).to eq('spa')
+    end
+
+    it 'updates driver and track names for all UserPicks' do
+      @pick1 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'leclerc', circuit_id: 'spa', driver_id_dnf: 'ocon')
+      @pick2 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'hamilton', circuit_id: 'monaco', driver_id_dnf: 'ricciardo')
+
+      UserPick.purify_pick_names
+
+      @pick1.reload
+      @pick2.reload
+
+      expect(@pick1.driver_id).to eq('Charles Leclerc')
+      expect(@pick1.race_name).to eq('Belgian Grand Prix')
+      expect(@pick1.dnf_name).to eq('Esteban Ocon')
+
+      expect(@pick2.driver_id).to eq('Lewis Hamilton')
+      expect(@pick2.race_name).to eq('Monaco Grand Prix')
+      expect(@pick2.dnf_name).to eq('Daniel Ricciardo')
     end
   end
 end

--- a/spec/models/user_pick_spec.rb
+++ b/spec/models/user_pick_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
   end
 
   describe 'model methods' do
-    it 'can set the current race' do
-      actual_next_race = 'spa'
-      user = User.create!(name: 'Bob', total_points: 0)
-      season = Season.create!(season_year: 2023)
-      UserSeason.create!(user_id: user.id, season_id: season.id)
-      user_pick = UserPick.create!(user_id: user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
-                                   driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: '')
+    # xit 'can set the current race' do
+    #   actual_next_race = 'spa'
+    #   user = User.create!(name: 'Bob', total_points: 0)
+    #   season = Season.create!(season_year: 2023)
+    #   UserSeason.create!(user_id: user.id, season_id: season.id)
+    #   user_pick = UserPick.create!(user_id: user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
+    #                                driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: '')
 
-      expect(user_pick.set_current_race).to eq(actual_next_race)
-    end
+    #   expect(user_pick.set_current_race).to eq(actual_next_race)
+    # end
 
     it 'can assign the finish position' do
       user = User.create!(name: 'Bob', total_points: 0)

--- a/spec/models/user_pick_spec.rb
+++ b/spec/models/user_pick_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
 
     it 'can assign the finish position' do
       @user_pick = UserPick.create!(user_id: @user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
-                                   driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: 'R')
+                                    driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: 'R')
       @user_pick.assign_finish_position
 
       expect(@user_pick.tenth_finish_position).to eq(1)
@@ -28,9 +28,9 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
 
     it 'can calculate the points earned' do
       @user_pick = UserPick.create!(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
-                                   driver_id_tenth: 'max_verstappen', tenth_finish_position: nil, dnf_finish_position: '')
+                                    driver_id_tenth: 'max_verstappen', tenth_finish_position: nil, dnf_finish_position: '')
       @user_pick2 = UserPick.create!(user_id: @user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'gasly',
-                                    driver_id_tenth: 'stroll', tenth_finish_position: nil, dnf_finish_position: '')
+                                     driver_id_tenth: 'stroll', tenth_finish_position: nil, dnf_finish_position: '')
 
       @user_pick.assign_finish_position
       @user_pick2.assign_finish_position
@@ -48,7 +48,7 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
     it 'add an error if the same driver is picked' do
       @user_pick = UserPick.new(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
                                 driver_id_tenth: 'ocon', tenth_finish_position: nil, dnf_finish_position: '')
-      @user_pick.valid?                             
+      @user_pick.valid?
 
       expect(@user_pick.errors.full_messages).to eq(["Driver id tenth can't be the same as DNF driver"])
     end
@@ -56,15 +56,15 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
     it "doesn't add an error if the same driver is not picked" do
       @user_pick = UserPick.new(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
                                 driver_id_tenth: 'hamilton', tenth_finish_position: nil, dnf_finish_position: '')
-        @user_pick.valid?                             
+      @user_pick.valid?
 
-        expect(@user_pick.errors.full_messages).to be_empty
+      expect(@user_pick.errors.full_messages).to be_empty
     end
 
     it 'can set the current race' do
       @user_pick = UserPick.new(user_id: @user.id, circuit_id: '', driver_id_dnf: 'russell',
                                 driver_id_tenth: 'hamilton', tenth_finish_position: nil, dnf_finish_position: '')
-      
+
       fixed_date = '2023-07-30'
       Timecop.freeze(fixed_date)
 
@@ -74,7 +74,8 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
 
     it 'updates driver and track names for all UserPicks' do
       @pick1 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'leclerc', circuit_id: 'spa', driver_id_dnf: 'ocon')
-      @pick2 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'hamilton', circuit_id: 'monaco', driver_id_dnf: 'ricciardo')
+      @pick2 = UserPick.create!(user_id: @user.id, driver_id_tenth: 'hamilton', circuit_id: 'monaco',
+                                driver_id_dnf: 'ricciardo')
 
       UserPick.purify_pick_names
 

--- a/spec/models/user_pick_spec.rb
+++ b/spec/models/user_pick_spec.rb
@@ -10,50 +10,66 @@ RSpec.describe UserPick, vcr: { record: :new_episodes }, type: :model do
   end
 
   describe 'model methods' do
-    # xit 'can set the current race' do
-    #   actual_next_race = 'spa'
-    #   user = User.create!(name: 'Bob', total_points: 0)
-    #   season = Season.create!(season_year: 2023)
-    #   UserSeason.create!(user_id: user.id, season_id: season.id)
-    #   user_pick = UserPick.create!(user_id: user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
-    #                                driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: '')
-
-    #   expect(user_pick.set_current_race).to eq(actual_next_race)
-    # end
+    before(:each) do
+      @user = User.create!(name: 'Bob', total_points: 0)
+      @user2 = User.create!(name: 'Joe', total_points: 0)
+      @season = Season.create!(season_year: 2023)
+      UserSeason.create!(user_id: @user.id, season_id: @season.id)
+      UserSeason.create!(user_id: @user2.id, season_id: @season.id)
+    end
 
     it 'can assign the finish position' do
-      user = User.create!(name: 'Bob', total_points: 0)
-      season = Season.create!(season_year: 2023)
-      UserSeason.create!(user_id: user.id, season_id: season.id)
-      user_pick = UserPick.create!(user_id: user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
+      @user_pick = UserPick.create!(user_id: @user.id, circuit_id: 'spa', driver_id_dnf: 'ocon',
                                    driver_id_tenth: 'hamilton', points_earned: 1, tenth_finish_position: 1, dnf_finish_position: 'R')
-      user_pick.assign_finish_position
+      @user_pick.assign_finish_position
 
-      expect(user_pick.tenth_finish_position).to eq(1)
+      expect(@user_pick.tenth_finish_position).to eq(1)
     end
 
     it 'can calculate the points earned' do
-      user = User.create!(name: 'Bob', total_points: 0)
-      user2 = User.create!(name: 'Joe', total_points: 0)
-      season = Season.create!(season_year: 2023)
-      UserSeason.create!(user_id: user.id, season_id: season.id)
-      UserSeason.create!(user_id: user2.id, season_id: season.id)
-      user_pick = UserPick.create!(user_id: user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
+      @user_pick = UserPick.create!(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
                                    driver_id_tenth: 'max_verstappen', tenth_finish_position: nil, dnf_finish_position: '')
-      user_pick2 = UserPick.create!(user_id: user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'gasly',
+      @user_pick2 = UserPick.create!(user_id: @user2.id, circuit_id: 'hungaroring', driver_id_dnf: 'gasly',
                                     driver_id_tenth: 'stroll', tenth_finish_position: nil, dnf_finish_position: '')
 
-      user_pick.assign_finish_position
-      user_pick2.assign_finish_position
+      @user_pick.assign_finish_position
+      @user_pick2.assign_finish_position
 
-      user_pick.calculate_points
-      user_pick2.calculate_points
+      @user_pick.calculate_points
+      @user_pick2.calculate_points
 
-      user_pick.dnf_points
-      user_pick2.dnf_points
+      @user_pick.dnf_points
+      @user_pick2.dnf_points
 
-      expect(user_pick.points_earned).to eq(1)
-      expect(user_pick2.points_earned).to eq(35)
+      expect(@user_pick.points_earned).to eq(1)
+      expect(@user_pick2.points_earned).to eq(35)
+    end
+
+    it 'add an error if the same driver is picked' do
+      @user_pick = UserPick.new(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
+                                driver_id_tenth: 'ocon', tenth_finish_position: nil, dnf_finish_position: '')
+      @user_pick.valid?                             
+
+      expect(@user_pick.errors.full_messages).to eq(["Driver id tenth can't be the same as DNF driver"])
+    end
+
+    it "doesn't add an error if the same driver is not picked" do
+      @user_pick = UserPick.new(user_id: @user.id, circuit_id: 'hungaroring', driver_id_dnf: 'ocon',
+                                driver_id_tenth: 'hamilton', tenth_finish_position: nil, dnf_finish_position: '')
+        @user_pick.valid?                             
+
+        expect(@user_pick.errors.full_messages).to be_empty
+    end
+
+    it 'can set the current race' do
+      @user_pick = UserPick.new(user_id: @user.id, circuit_id: '', driver_id_dnf: 'russell',
+                                driver_id_tenth: 'hamilton', tenth_finish_position: nil, dnf_finish_position: '')
+      
+      fixed_date = '2023-07-30'
+      Timecop.freeze(fixed_date)
+
+      current_race = @user_pick.set_cburrent_race
+      expect(current_race).to eq('spa')
     end
   end
 end


### PR DESCRIPTION
This PR fixes issue where points weren't updating on the `user_picks#index` and `leaderboard#show` pages and adds more robust testing.
- Tests currently passing at: 100%

1. chore: add `timecop` gem
2. chore: create `@last_6` method in `user_picks#index` method
3. chore: update seeds file with Belgian GP picks
4. feat: add `@last_6` logic to the `user_pick#index` view
5. test: more robust testing with happy and sad paths for some model methods
6. refactor: get rid of extraneous `prys` and commented out code
7. refactor: rubocop fixes
8. refactor: get rid of `Rails.cache` because it isn't working. Will come back to this later