### PR TITLE
Style leaderboard tables

### DIFF
--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -72,6 +72,6 @@ class SeasonsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def season_params
-    params.require(:season).permit(:season_year)
+    params.require(:season).permit(:season_year, :id)
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,8 +26,16 @@
         <%= image_tag 'logo.png', title: "P10 Racing Logo", class: "logo h-5 shadow-sm" %>
       </a>  
       
-      <div id='leaderboard_button' class="justify-end">
+      <!-- <div id='leaderboard_button' class="float-right ml-auto text-sm font-bold text-center border-2 border-red-700 rounded shadow-md fold-bold sm:w-40 text-red-700 hover:bg-red-700 hover:text-white">
         <%= button_to "Leaderboard", leaderboard_index_path, method: :get %>
       </div>
-    </div>
+
+      <div id='home_button', class='ml-auto text-sm font-bold text-center border-2 border-red-700 rounded shadow-md fold-bold sm:w-40 text-red-700 hover:bg-red-700 hover:text-white'>
+        <%= link_to "Back to Season Home Page", season_path(Season.last.season_year), method: :get %>
+      </div> -->
+
+      <div class='flex items-center'>
+        <%= button_to "Leaderboard", leaderboard_index_path, method: :get, class: 'ml-auto text-sm font-bold text-center border-2 border-red-700 rounded shadow-md fold-bold sm:w-40 text-red-700 hover:bg-red-700 hover:text-white' %>
+        <%= button_to "Season Home", season_path(Season.last.id), method: :get, class: 'ml-4 text-sm font-bold text-center border-2 bg-red-700 rounded shadow-md fold-bold sm:w-40 text-white hover:bg-white hover:text-red-700' %>
+      </div>
   </header>

--- a/app/views/leaderboard/index.html.erb
+++ b/app/views/leaderboard/index.html.erb
@@ -1,8 +1,10 @@
 <div class="flex flex-row justify-around"> <!-- This is the start of the leaderboard row -->
   <div class="flex flex-col"> <!-- this starts the user-standings-table -->
-    <h1>Leaderboard</h1>
-    <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-      <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+    <div class="font-bold text-xl pb-4">
+      <h1>Player and Driver Standings:</h1>
+    </div>
+    <table class="w-full text-md text-left text-black dark:text-white table-auto border-2 pt-4 border-collapse rounded-md border-spacing-5 shadow-md">
+      <thead class="px-4 text-lg text-black uppercase bg-red-400 dark:bg-gray-700 dark:text-gray-400 ">
         <tr>
           <th class="pr-4">Position</th>
           <th class="pr-4">Player Name</th>
@@ -12,7 +14,7 @@
       <tbody>
         <% @users.each do |user| %>
           <% user.calculate_total_points %>
-          <tr>
+          <tr class="font-med <%= @position.even? ? 'bg-red-200 dark:bg-gray-600' : '' %>">
             <td class="pr-4 text-center"><%= @position %></td>
             <td class="pr-4 text-center"><%= user.name %></td>
             <td class="pl-1 text-center"><%= user.total_points %></td>
@@ -29,20 +31,20 @@
     <% @drivers.each do |driver| %>
       <% points_earned_by_driver[driver.driver_id] = UserPick.where(driver_id_tenth: driver.driver_id).sum { |pick| pick.points_earned } %>
     <% end %>
-
     <% @drivers.sort_by! { |driver| -points_earned_by_driver[driver.driver_id]} %>
-    <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400 mt-6">
-      <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+
+    <table class="w-full text-sm text-left mt-12 text-black dark:text-white table-auto border-2 p-4 border-collapse rounded-md my-5 shadow-md">
+      <thead class="text-xl text-black uppercase bg-red-400 dark:bg-gray-700 dark:text-gray-400">
         <tr>
           <th class="pr-4 text-center">Position</th>
           <th class="pr-2 text-center">Driver</th>
-          <th class="pr-2 text-center">Points earned from pick</th>
+          <th class="pr-2 text-center">Points earned when picked</th>
         </tr>
       </thead>
       <tbody>
       <% @position = 1 %>
         <% @drivers.each do |driver| %>
-          <tr>
+          <tr class="text-lg <%= @position.even? ? 'bg-red-200 dark:bg-gray-600' : '' %>">
             <td class="pr-4 text-center"><%= @position %></td>
             <td class="pr-2 text-center"><%= driver.name %></td>
             <td class=" text-center"><%= points_earned_by_driver[driver.driver_id] %> </td>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -79,10 +79,10 @@
       <h4>Race: <%= @next_race[:date].to_date.strftime('%B %d') %>: <%= @next_race[:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %> </h4>
       <br>
       <% if @next_race[:ThirdPractice] %>
-        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%B %d') %></p>
-        <p>Free Practice 2: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%B %d') %></p>
-        <p>Free Practice 3: <%=  @next_race[:ThirdPractice][:date].to_date.strftime('%B %d') %></p>
-        <p>Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%B %d') %></p>
+        <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%B %d')%>:  <%= @next_race[:FirstPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Free Practice 2: <%=  @next_race[:SecondPractice][:date].to_date.strftime('%B %d')%>: <%= @next_race[:SecondPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Free Practice 3: <%=  @next_race[:ThirdPractice][:date].to_date.strftime('%B %d')%>: <%= @next_race[:ThirdPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
+        <p>Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%B %d')%>: <%= @next_race[:Qualifying][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
       <% else %>
         <p>Free Practice 1: <%=  @next_race[:FirstPractice][:date].to_date.strftime('%B %d') %>: <%= @next_race[:FirstPractice][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>
         <p>Race Qualifying: <%=  @next_race[:Qualifying][:date].to_date.strftime('%B %d') %>: <%= @next_race[:Qualifying][:time].to_time.in_time_zone('Mountain Time (US & Canada)').strftime('%I:%M %p') %></p>


### PR DESCRIPTION
This PR styles the leaderboard page's tables
- Tests still passing at 100%

- chore: update season params to allow for the link to the show page from the header
- style: make buttons in the header look like they are buttons that are clickable
- style: make the tables easier to read