### PR TITLE
chore: update seeds file to destroy all before redeploy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,11 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+User.destroy_all
+Season.destroy_all
+UserSeason.destroy_all
+UserPick.destroy_all
+
 user1 = User.create!(name: 'Stephen')
 user2 = User.create!(name: 'Chase')
 user3 = User.create!(name: 'T')


### PR DESCRIPTION
- This PR adds `{Model}.destroy_all` to the top of the seeds file so data is duplicated on redeploys